### PR TITLE
updating charts, cluster, and documentation for newer versions

### DIFF
--- a/docs/deploy_cluster.md
+++ b/docs/deploy_cluster.md
@@ -15,7 +15,7 @@ To test this sample repository you need an Amazon EKS cluster with [AWS Load Bal
 1. Create an IAM Policy to grant permissions to AWS Load Balancer Controller to create and manage Load Balancers. We will use eksctl later to create an IAM Role for the aws-load-balancer-controller Service account.
 
     ```bash
-    curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.0/docs/install/iam_policy.json
+    curl -o iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.5.4/docs/install/iam_policy.json
     aws iam create-policy \
       --policy-name AWSLoadBalancerControllerIAMPolicy \
       --policy-document file://iam_policy.json
@@ -27,7 +27,7 @@ To test this sample repository you need an Amazon EKS cluster with [AWS Load Bal
 
     ```bash
     git clone https://github.com/aws-samples/flux-eks-gitops-config.git
-    cd k8s-infra
+    cd flux-eks-gitops-config
     ```
 
 1. Within `docs/examples/cluster.yaml`, in the `iam:` section, we're defining an IAM Role for service account aws-load-balancer-controller in the kube-system namespace. Update line 24 with the IAM policy ARN of the policy you've created in the prior step.
@@ -39,7 +39,7 @@ To test this sample repository you need an Amazon EKS cluster with [AWS Load Bal
 1. Create the EKS cluster running the following command. It will take 15-20 minutes to create the cluster.
 
     ```bash
-    eksctl create cluster -f docs/examples/cluster.yaml
+    eksctl create cluster -f docs/examples/eks-cluster/cluster.yaml
     ```
 
 You're all set. You can now go to the ![deploy section](../README.md#deploy-this-sample).

--- a/docs/examples/eks-cluster/cluster.yaml
+++ b/docs/examples/eks-cluster/cluster.yaml
@@ -5,7 +5,7 @@ kind: ClusterConfig
 metadata:
   name: my-eks-cluster 
   region: us-west-2
-  version: "1.22"
+  version: "1.27"
 
 managedNodeGroups:
   - name: system-ng

--- a/infrastructure/base/addons/calico/tigera-operator.yaml
+++ b/infrastructure/base/addons/calico/tigera-operator.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: tigera-operator
-      version: v3.23.1
+      version: v3.26.1
       sourceRef:
         kind: HelmRepository
         name: projectcalico

--- a/infrastructure/base/addons/nginx-ingress-controller/release.yaml
+++ b/infrastructure/base/addons/nginx-ingress-controller/release.yaml
@@ -14,7 +14,7 @@ spec:
         kind: HelmRepository
         name: ingress-nginx
         namespace: flux-system
-      version: 4.1.1
+      version: 4.7.1
   values:
     controller:
       metrics:

--- a/infrastructure/production/patch-ingress-nginx.yaml
+++ b/infrastructure/production/patch-ingress-nginx.yaml
@@ -3,9 +3,6 @@ kind: HelmRelease
 metadata:
   name: ingress-nginx
 spec:
-  chart:
-    spec:
-      version: 4.1.0
   values:
     controller:
       resources:


### PR DESCRIPTION
*Description of changes:*

I found the documentation was inaccurate for deploying the EKS cluster via eksctl. I updated the documentation, cluster version, and load-balancer policy version. I also updated the nginx and calico helm charts to current versions. The old ones used APIs that are not longer available.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
