### PR TITLE
Fixes for K8s 1.27 and Flux 2.1.2

### DIFF
--- a/infrastructure/base/addons/flagger/release.yaml
+++ b/infrastructure/base/addons/flagger/release.yaml
@@ -10,7 +10,7 @@ spec:
   chart:
     spec:
       chart: flagger
-      version: 1.21.0
+      version: 1.34.0
       sourceRef:
         kind: HelmRepository
         name: flagger

--- a/infrastructure/production/patch-flagger.yaml
+++ b/infrastructure/production/patch-flagger.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 1.12.0
+      version: 1.34.0

--- a/infrastructure/test/patch-flagger.yaml
+++ b/infrastructure/test/patch-flagger.yaml
@@ -5,4 +5,4 @@ metadata:
 spec:
   chart:
     spec:
-      version: 1.12.1
+      version: 1.34.0

--- a/tenants/base/podinfo-team/source.yaml
+++ b/tenants/base/podinfo-team/source.yaml
@@ -22,4 +22,3 @@ spec:
     kind: GitRepository
     name: podinfo-team
   prune: true
-  validation: client


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/flux-eks-gitops-config-tenant/issues/1

*Description of changes:* In recent versions of Flux, the beta APIs are deprecated, and the `validation` property is not part of the schema of `kustomize.toolkit.fluxcd.io/v1`, so the `podinfo-team` Kustomization fails to be created. Also, flagger version `1.21.0` fails to create the podinfo canary on K8s 1.27 (default K8s version created by eksctl). Updated version to `1.34.0`. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
